### PR TITLE
Fix cloudflared warnings/errors by adding Stop/Start service

### DIFF
--- a/packages/cloudflared/Update.ps1
+++ b/packages/cloudflared/Update.ps1
@@ -16,27 +16,27 @@ if ($LatestVersion -in $AvailablePackages) {
 # Update the install script
 $InstallPs1 = Get-Content $PSScriptRoot\tools\chocolateyInstall.ps1
 $Replacements = @{
-    "url"        = $LatestRelease.assets.Where{$_.name -eq 'cloudflared-windows-386.exe'}.browser_download_url
-    "url64bit"   = $LatestRelease.assets.Where{$_.name -eq 'cloudflared-windows-amd64.exe'}.browser_download_url
+    "url"      = $LatestRelease.assets.Where{ $_.name -eq 'cloudflared-windows-386.exe' }.browser_download_url
+    "url64bit" = $LatestRelease.assets.Where{ $_.name -eq 'cloudflared-windows-amd64.exe' }.browser_download_url
 }
 
 try {
-    $Replacements.checksum   = ($LatestRelease.body.Split("`n") -match 'cloudflared-windows-386.exe: (?<CheckSum>\w+)').Split(': ')[-1]
+    $Replacements.checksum = ($LatestRelease.body.Split("`n") -match 'cloudflared-windows-386.exe: (?<CheckSum>\w+)').Split(': ')[-1]
     $Replacements.checksum64 = ($LatestRelease.body.Split("`n") -match 'cloudflared-windows-amd64.exe: (?<CheckSum>\w+)').Split(': ')[-1]
 } catch {
     Write-Warning "Release body did not contain checksums. Falling back to manual calculation."
 
-    $Replacements.checksum   = (Get-FileHash -Algorithm SHA256 -InputStream (
-        [System.IO.MemoryStream]::New(
+    $Replacements.checksum = (Get-FileHash -Algorithm SHA256 -InputStream (
+            [System.IO.MemoryStream]::New(
             (Invoke-WebRequest $Replacements.url).Content
-        )
-    )).Hash
+            )
+        )).Hash
 
     $Replacements.checksum64 = (Get-FileHash -Algorithm SHA256 -InputStream (
-        [System.IO.MemoryStream]::New(
+            [System.IO.MemoryStream]::New(
             (Invoke-WebRequest $Replacements.url64bit).Content
-        )
-    )).Hash
+            )
+        )).Hash
 }
 
 $Replacements.GetEnumerator().ForEach{

--- a/packages/cloudflared/cloudflared.nuspec
+++ b/packages/cloudflared/cloudflared.nuspec
@@ -1,32 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
-  <metadata>
-    <id>cloudflared</id>
-    <title>cloudflared</title>
-    <version>$version$</version>
-    <authors>Cloudflare</authors>
-    <owners>jpruskin</owners>
-    <summary>The command-line client for Argo Tunnel, a tunneling daemon that proxies any local webserver through the Cloudflare network.</summary>
-    <description>You can connect applications, servers, and other resources to Cloudflare's network using Cloudflare Tunnel. When connected, Cloudflare can apply Zero Trust policies to determine who can reach the resource.
+    <metadata>
+        <id>cloudflared</id>
+        <title>cloudflared</title>
+        <version>$version$</version>
+        <authors>Cloudflare</authors>
+        <owners>jpruskin</owners>
+        <summary>The command-line client for Argo Tunnel, a tunneling daemon that proxies any local webserver through the Cloudflare network.</summary>
+        <description>You can connect applications, servers, and other resources to Cloudflare's network using Cloudflare Tunnel. When connected, Cloudflare can apply Zero Trust policies to determine who can reach the resource.
 
 When Cloudflare receives a request for your chosen hostname, it proxies the request through those connections to cloudflared. In turn, cloudflared proxies the request to your applications.
 
 This package is particularly suited to installing the CLI executable for use tunnelling to infrastructure using [Cloudflare Access](https://www.cloudflare.com/en-gb/teams/access/) as it contains only the standalone binary, and does not configure or create services.
 
 Please see [Useful commands](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/tunnel-useful-commands) for usage examples.</description>
-    <releaseNotes>https://github.com/cloudflare/cloudflared/releases</releaseNotes>
-    <projectUrl>https://www.cloudflare.com/en-gb/products/tunnel/</projectUrl>
-    <iconUrl>https://rawcdn.githack.com/jpruskin/ChocolateyPackages/master/icons/cloudflared.svg</iconUrl>
-    <licenseUrl>https://github.com/cloudflare/cloudflared/blob/master/LICENSE</licenseUrl>
-    <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/cloudflare/cloudflared</projectSourceUrl>
-    <packageSourceUrl>https://github.com/JPRuskin/ChocolateyPackages/tree/main/packages/cloudflared</packageSourceUrl>
-    <docsUrl>https://developers.cloudflare.com/cloudflare-one/connections/connect-apps</docsUrl>
-    <bugTrackerUrl>https://github.com/cloudflare/cloudflared/issues</bugTrackerUrl>
-    <tags>cloudflared cloudflare argo tunnel</tags>
-  </metadata>
-  <files>
-    <file src="tools\**" target="tools" />
-  </files>
+        <releaseNotes>https://github.com/cloudflare/cloudflared/releases</releaseNotes>
+        <projectUrl>https://www.cloudflare.com/en-gb/products/tunnel/</projectUrl>
+        <iconUrl>https://rawcdn.githack.com/jpruskin/ChocolateyPackages/master/icons/cloudflared.svg</iconUrl>
+        <licenseUrl>https://github.com/cloudflare/cloudflared/blob/master/LICENSE</licenseUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <projectSourceUrl>https://github.com/cloudflare/cloudflared</projectSourceUrl>
+        <packageSourceUrl>https://github.com/JPRuskin/ChocolateyPackages/tree/main/packages/cloudflared</packageSourceUrl>
+        <docsUrl>https://developers.cloudflare.com/cloudflare-one/connections/connect-apps</docsUrl>
+        <bugTrackerUrl>https://github.com/cloudflare/cloudflared/issues</bugTrackerUrl>
+        <tags>cloudflared cloudflare argo tunnel</tags>
+    </metadata>
+    <files>
+        <file src="tools\**" target="tools" />
+    </files>
 </package>

--- a/packages/cloudflared/tools/chocolateyBeforeModify.ps1
+++ b/packages/cloudflared/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+
+# Stop the cloudflared service if it is running
+$serviceName = 'cloudflared'
+$service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+if ($service) {
+    if ($service.Status -eq 'Running') {
+        Write-Output "Stopping service '$serviceName'"
+        Stop-Service -Name $serviceName
+    }
+}

--- a/packages/cloudflared/tools/chocolateyUninstall.ps1
+++ b/packages/cloudflared/tools/chocolateyUninstall.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+
+# Stop the cloudflared service if it is running
+$serviceName = 'cloudflared'
+$service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+if ($service) {
+    if ($service.Status -eq 'Running') {
+        Write-Output "Stopping service '$serviceName'"
+        Stop-Service -Name $serviceName
+    }
+}

--- a/packages/cloudflared/tools/chocolateyinstall.ps1
+++ b/packages/cloudflared/tools/chocolateyinstall.ps1
@@ -1,17 +1,39 @@
 ﻿$ErrorActionPreference = 'Stop'
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
-  FileFullPath  = Join-Path $toolsDir "cloudflared.exe"
+# Tools directory
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-  url           = 'https://github.com/cloudflare/cloudflared/releases/download/$version$/cloudflared-windows-386.exe'
-  url64bit      = 'https://github.com/cloudflare/cloudflared/releases/download/$version$/cloudflared-windows-amd64.exe'
-
-  checksum      = '6dba2c4b43af7302cfdbae791a47e885dbbb366f01842e5aea13a24fbdb5f552'
-  checksumType  = 'sha256'
-  checksum64    = '3cf5585fb3b00e6b01d562c86fb63bac96ae003eed610aacb8ca1bebc1390969'
-  checksumType64= 'sha256'
+# Stop the cloudflared service if it is running
+$serviceName = 'cloudflared'
+$service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+if ($service) {
+    if ($service.Status -eq 'Running') {
+        Write-Output "Stopping service '$serviceName'"
+        Stop-Service -Name $serviceName
+    }
 }
 
+# Package parameters
+$packageArgs = @{
+    packageName    = $env:ChocolateyPackageName
+    FileFullPath   = Join-Path $toolsDir "cloudflared.exe"
+
+    url            = 'https://github.com/cloudflare/cloudflared/releases/download/$version$/cloudflared-windows-386.exe'
+    url64bit       = 'https://github.com/cloudflare/cloudflared/releases/download/$version$/cloudflared-windows-amd64.exe'
+
+    checksum       = '6dba2c4b43af7302cfdbae791a47e885dbbb366f01842e5aea13a24fbdb5f552'
+    checksumType   = 'sha256'
+    checksum64     = '3cf5585fb3b00e6b01d562c86fb63bac96ae003eed610aacb8ca1bebc1390969'
+    checksumType64 = 'sha256'
+}
+
+# Download cloudflared.exe
 Get-ChocolateyWebFile @packageArgs
+
+# If the service was previously running, start it again
+if ($service) {
+    if ($service.Status -eq 'Running') {
+        Write-Output "Starting service '$serviceName'"
+        Start-Service -Name $serviceName
+    }
+}


### PR DESCRIPTION
Hey there, I noticed that `cloudflared` was having some trouble removing the older versions because if it's already running then it won't be able to remove the old files.

![image](https://github.com/JPRuskin/ChocolateyPackages/assets/49938263/2463ec87-77c1-42ed-90e1-ea7e484a929d)

I adjusted the script so that it will stop the `cloudflared` service first, install/upgrade `cloudflared`, then if the service was running before, start it again.

I also added the functionality to stop the service when uninstalling, as well as before modification. This should ensure that the service is started.

In addition, I formatted the code in VS Code using `Ctrl+Alt+F` w/PowerShell extension.