### PR TITLE
Fix monaspace upgrade failures

### DIFF
--- a/packages/monaspace/tools/chocolateyInstall.ps1
+++ b/packages/monaspace/tools/chocolateyInstall.ps1
@@ -5,13 +5,15 @@ $packageArgs = @{
     PackageName    = $env:ChocolateyPackageName
     FileFullPath   = Join-Path $toolsDir "monaspace.zip"
     Destination    = "$toolsDir/fonts"
-    Checksum       = '3E08376FD0AECA1F851FDE0C08E18CA2D797F6A4C7A449670BF4D1270303C8F6'
+    Checksum       = '7FF2317C7BDAED8E81DCBE1314E6AB12AD9641B7DDF921E996A227FF4EC7752F'
     ChecksumType   = 'sha256'
 }
 
 Get-ChocolateyUnzip @packageArgs
 
 $FontDirectory = (New-Object -ComObject Shell.Application).namespace(0x14).self.path
+$RegistryPath = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts\'
+$RegisteredFonts = Get-ItemProperty -path $RegistryPath
 
 foreach ($Font in Get-ChildItem -Path "$toolsDir/fonts" -Include ('*.otf', '*.ttf') -Recurse) {
     Write-Verbose "Installing Font - $($Font.BaseName)"
@@ -20,11 +22,14 @@ foreach ($Font in Get-ChildItem -Path "$toolsDir/fonts" -Include ('*.otf', '*.tt
     # Register font for all users
     $FontRegistryEntry = @{
         Name         = $Font.BaseName
-        Path         = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Fonts"
+        Path         = $RegistryPath
         PropertyType = "String"
         Value        = $Font.Name
     }
-    if (-not (Get-ItemProperty -Path $FontRegistryEntry.Path -Name $FontRegistryEntry.Name -ErrorAction SilentlyContinue)) {
+    if (-not (Get-Member -InputObject $RegisteredFonts | ? Name -eq $FontRegistryEntry.Name)) {
+        Write-Host $FontRegistryEntry.Name
+        Get-Member -InputObject $RegisteredFonts | ? Name -eq $FontRegistryEntry.Name
+        Get-ItemProperty -Path $FontRegistryEntry.Path -Name $FontRegistryEntry.Name -ErrorAction SilentlyContinue
         $null = New-ItemProperty @FontRegistryEntry
     }
 }

--- a/packages/monaspace/tools/chocolateyInstall.ps1
+++ b/packages/monaspace/tools/chocolateyInstall.ps1
@@ -12,8 +12,6 @@ $packageArgs = @{
 Get-ChocolateyUnzip @packageArgs
 
 $FontDirectory = (New-Object -ComObject Shell.Application).namespace(0x14).self.path
-$RegistryPath = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts\'
-$RegisteredFonts = Get-ItemProperty -path $RegistryPath
 
 foreach ($Font in Get-ChildItem -Path "$toolsDir/fonts" -Include ('*.otf', '*.ttf') -Recurse) {
     Write-Verbose "Installing Font - $($Font.BaseName)"
@@ -22,14 +20,8 @@ foreach ($Font in Get-ChildItem -Path "$toolsDir/fonts" -Include ('*.otf', '*.tt
     # Register font for all users
     $FontRegistryEntry = @{
         Name         = $Font.BaseName
-        Path         = $RegistryPath
-        PropertyType = "String"
+        Path         = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts\"
         Value        = $Font.Name
     }
-    if (-not (Get-Member -InputObject $RegisteredFonts | ? Name -eq $FontRegistryEntry.Name)) {
-        Write-Host $FontRegistryEntry.Name
-        Get-Member -InputObject $RegisteredFonts | ? Name -eq $FontRegistryEntry.Name
-        Get-ItemProperty -Path $FontRegistryEntry.Path -Name $FontRegistryEntry.Name -ErrorAction SilentlyContinue
-        $null = New-ItemProperty @FontRegistryEntry
-    }
+    $null = Set-ItemProperty @FontRegistryEntry
 }


### PR DESCRIPTION
If monaspace is already installed, it fails to upgrade because some of the font names can't be found with `Get-ItemProperty`. This changes the detection to a way that works for these names.

I have tested this by using this exact code in a local copy of the package (hence why it changes the checksum).